### PR TITLE
PULSE annotations to support bwf-pool-race branch of riak_core

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -9,6 +9,13 @@
 -export([init/1, ready/2, ready/3, overflow/2, overflow/3, full/2, full/3,
          handle_event/3, handle_sync_event/4, handle_info/3, terminate/3,
          code_change/4]).
+-ifdef(PULSE).
+-compile(export_all).
+-compile({parse_transform, pulse_instrument}).
+-compile({pulse_replace_module, [{gen_fsm, pulse_gen_fsm},
+                                 {gen_server, pulse_gen_server},
+                                 {supervisor, pulse_supervisor}]}).
+-endif.
 
 -define(TIMEOUT, 5000).
 

--- a/src/poolboy_sup.erl
+++ b/src/poolboy_sup.erl
@@ -4,6 +4,11 @@
 -behaviour(supervisor).
 
 -export([start_link/2, init/1]).
+-ifdef(PULSE).
+-compile(export_all).
+-compile({parse_transform, pulse_instrument}).
+-compile({pulse_replace_module, [{supervisor, pulse_supervisor}]}).
+-endif.
 
 start_link(Mod, Args) ->
     supervisor:start_link(?MODULE, {Mod, Args}).

--- a/src/poolboy_worker.erl
+++ b/src/poolboy_worker.erl
@@ -3,6 +3,10 @@
 -module(poolboy_worker).
 
 -export([behaviour_info/1]).
+-ifdef(PULSE).
+-compile(export_all).
+-compile({parse_transform, pulse_instrument}).
+-endif.
 
 behaviour_info(callbacks) ->
     [{start_link, 1}];


### PR DESCRIPTION
The worker_pool_pulse.erl test in riak_core, part of basho/riak_core#300, needs poolboy to be compiled with PULSE annotations. This commit provides those.
