### PR TITLE
Fix queue/0 type deprecations (with queue:queue/0)

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -21,8 +21,8 @@
 
 -record(state, {
     supervisor :: pid(),
-    workers :: queue(),
-    waiting :: queue(),
+    workers :: queue:queue(),
+    waiting :: queue:queue(),
     monitors :: ets:tid(),
     size = 5 :: non_neg_integer(),
     overflow = 0 :: non_neg_integer(),


### PR DESCRIPTION
When including the latest on `develop` for poolboy as a dependency in an Erlang project, rebar aborted with a warning as error with the following messages:

```
/Users/susan.potter/Code/oss/carson/deps/poolboy/src/poolboy.erl:24: type queue/0 is deprecated and will be removed in
 OTP 18.0; use use queue:queue/0 or preferably queue:queue/1                                                          
/Users/susan.potter/Code/oss/carson/deps/poolboy/src/poolboy.erl:25: type queue/0 is deprecated and will be removed in
 OTP 18.0; use use queue:queue/0 or preferably queue:queue/1                                                          
ERROR: compile failed while processing /Users/susan.potter/Code/oss/carson/deps/poolboy: rebar_abort
```

_This pull request addresses the above deprecations so I can build keeping with `warnings_as_errors` on, which I prefer. This might break compatibility with much older versions of Erlang but for practical purposes I do not believe this will pose a problem for versions that poolboy wishes to support._

This is the [erlang-questions ML thread](http://erlang.org/pipermail/erlang-questions/2014-March/078081.html) where Andreas Schumacher
outlines the deprecation warnings in R17 to prepare the way for R18.0.
