### PR TITLE
Fix types to make Erlang 17 compatible.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
-{erl_opts, [debug_info, warnings_as_errors]}.
+{erl_opts, [debug_info, warnings_as_errors,
+            {platform_define, "^[0-9]+", namespaced_types}]}.
 {eunit_opts, [verbose]}.
 {cover_enabled, true}.

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -19,10 +19,16 @@
 
 -define(TIMEOUT, 5000).
 
+-ifdef(namespaced_types).
+-type poolboy_queue() :: queue:queue().
+-else.
+-type poolboy_queue() :: queue().
+-endif.
+
 -record(state, {
     supervisor :: pid(),
-    workers :: queue(),
-    waiting :: queue(),
+    workers :: poolboy_queue(),
+    waiting :: poolboy_queue(),
     monitors :: ets:tid(),
     size = 5 :: non_neg_integer(),
     overflow = 0 :: non_neg_integer(),


### PR DESCRIPTION
Use meck trick for supporting backwards namespaced types.
