### PR TITLE
Avoid crash.log error on shutdown

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -307,6 +307,8 @@ handle_info({'EXIT', Pid, _Reason}, StateName, State) ->
 handle_info(_Info, StateName, State) ->
     {next_state, StateName, State}.
 
+terminate(shutdown, _StateName, #state{workers=Workers}) ->
+    lists:foreach(fun (W) -> unlink(W) end, queue:to_list(Workers));
 terminate(_Reason, _StateName, _State) ->
     ok.
 


### PR DESCRIPTION
Proposed https://github.com/llelf/poolboy/commit/5cf64d635343ad8d6ad99484280a87a3e95bd804

An adaptation of:

https://github.com/devinus/poolboy/pull/53/files